### PR TITLE
Fix checking existed app

### DIFF
--- a/web/src/main/resources/org/geogebra/web/resources/js/deployggb-template.js
+++ b/web/src/main/resources/org/geogebra/web/resources/js/deployggb-template.js
@@ -542,7 +542,7 @@ var GGBApplet = function() {
         var appName = parameters.id !== undefined ? parameters.id : removedID;
         var app = window[appName];
 
-        if (typeof app === "object" && typeof app.getBase64 === "function") { // Check if the variable is a GeoGebra Applet and remove it
+        if (app && typeof app === "object" && typeof app.getBase64 === "function") { // Check if the variable is a GeoGebra Applet and remove it
             app.remove();
             window[appName] = null;
         }


### PR DESCRIPTION
If `window[appName]` is `null` then error thrown like 'Can't get getBase64 of null' because `typeof null` returns `object` (javascript bug), so it needs to check `app` first. It appeared after call `applet.removeExistingApplet` manually.