### PR TITLE
Add brackets around x when replacing

### DIFF
--- a/common/src/main/java/org/geogebra/common/export/pstricks/GeoGebraToPgf.java
+++ b/common/src/main/java/org/geogebra/common/export/pstricks/GeoGebraToPgf.java
@@ -436,7 +436,7 @@ public abstract class GeoGebraToPgf extends GeoGebraExport {
 			codeFilledObject.append(b);
 			codeFilledObject.append("] plot");
 			codeFilledObject.append("(\\x,{");
-			value = replaceX(value, "\\x");
+			value = replaceX(value, "(\\x)");
 			codeFilledObject.append(value);
 			codeFilledObject.append("})");
 		}
@@ -478,7 +478,7 @@ public abstract class GeoGebraToPgf extends GeoGebraExport {
 			codeFilledObject.append(a);
 			codeFilledObject.append("] -- plot");
 			codeFilledObject.append("(\\x,{");
-			value = replaceX(value, "\\x");
+			value = replaceX(value, "(\\x)");
 			codeFilledObject.append(value);
 			codeFilledObject.append("})");
 		}
@@ -561,7 +561,7 @@ public abstract class GeoGebraToPgf extends GeoGebraExport {
 				codeFilledObject.append(b);
 				codeFilledObject.append("] plot");
 				codeFilledObject.append("(\\x,{");
-				value = replaceX(value, "\\x");
+				value = replaceX(value, "(\\x)");
 				codeFilledObject.append(value);
 				codeFilledObject.append("})");
 			}


### PR DESCRIPTION
Fixes a bug for incorrect behaviour with negative numbers
e.g. Drawing the area under x^2 from -2 to 1 produces incorrect results.
Integral(x^2, -2, 1) produces \draw ... \x^2 which causes negative values to be drawn incorrectly.
This fix replaces it with (\x)^2