### PR TITLE
Fix not showing correct settings from more menu

### DIFF
--- a/web/src/main/java/org/geogebra/web/full/gui/view/algebra/contextmenu/action/SettingsAction.java
+++ b/web/src/main/java/org/geogebra/web/full/gui/view/algebra/contextmenu/action/SettingsAction.java
@@ -13,6 +13,7 @@ public class SettingsAction extends DefaultMenuAction<GeoElement> {
 	public void execute(GeoElement item, AppWFull app) {
 		ArrayList<GeoElement> list = new ArrayList<>();
 		list.add(item);
+		app.getSelectionManager().setSelectedGeos(list, true);
 		app.getDialogManager().showPropertiesDialog(OptionType.OBJECTS, list);
 	}
 }


### PR DESCRIPTION

When "Settings" is selected in the item more menu (the three dots), it only opens the settings. However, it will show the settings of the currently selected item as the settings are always shown of the selected item(s) - in contrast to the other actions in the same menu -. Selecting "Settings" should show the settings of the item that owns the chosen menu.

This PR fixes this problem by updating the selection when clicking on the Settings menu item.