### PR TITLE
Add type attribute to DOM-button

### DIFF
--- a/web-common/src/main/java/org/geogebra/web/html5/gui/view/button/StandardButton.java
+++ b/web-common/src/main/java/org/geogebra/web/html5/gui/view/button/StandardButton.java
@@ -11,6 +11,7 @@ import org.gwtproject.resources.client.ImageResource;
 import org.gwtproject.resources.client.ResourcePrototype;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -25,7 +26,9 @@ public class StandardButton extends Widget implements HasResource {
 	private Label colorLbl;
 
 	protected StandardButton() {
-		setElement(DOM.createButton());
+		Element btn = DOM.createButton();
+		btn.setAttribute("type", "button");
+		setElement(btn);
 		// for cursor: pointer
 		addStyleName("button");
 	}

--- a/web-dev/src/main/java/org/geogebra/web/html5/gui/util/ToggleButton.java
+++ b/web-dev/src/main/java/org/geogebra/web/html5/gui/util/ToggleButton.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.geogebra.common.kernel.geos.GeoElement;
 import org.gwtproject.resources.client.ResourcePrototype;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Label;
@@ -23,7 +24,9 @@ public class ToggleButton extends FocusWidget {
 	 * constructor
 	 */
 	public ToggleButton() {
-		setElement(DOM.createButton());
+		Element btn = DOM.createButton();
+		btn.setAttribute("type", "button");
+		setElement(btn);
 		addStyleName("button");
 	}
 


### PR DESCRIPTION
Buttons inside GeoGebra do not specify a type attribute. Without the browser always defaults to type="submit".

This means that if the applet is embedded inside a Form, every button press in the GeoGebra applet submits the surrounding form. 

Adding type="button" prevents that.