### PR TITLE
fix toolbar reseting after fileNew

### DIFF
--- a/desktop/src/main/java/org/geogebra/desktop/main/AppD.java
+++ b/desktop/src/main/java/org/geogebra/desktop/main/AppD.java
@@ -1300,8 +1300,14 @@ public class AppD extends App implements KeyEventDispatcher, AppDI {
 
 		resetAllToolbars();
 
+		// store current location of the window
+		storeFrameCenter();
+
 		// reload the saved/(default) preferences
 		GeoGebraPreferencesD.getPref().loadXMLPreferences(this);
+
+		getGuiManager().updateGUIafterLoadFile(true,false);
+
 		resetUniqueId();
 	}
 


### PR DESCRIPTION
### Fix this problem:

#### step 1. change the order of tools in toolbar:
![2022-09-17_202644](https://user-images.githubusercontent.com/8469304/190856745-ed096ffd-1161-41aa-8ef4-81a3c66ef944.png)
then apply and save settings.

#### step 2. reopen geogebra, the order of tools is indeed saved:
![2022-09-17_201847](https://user-images.githubusercontent.com/8469304/190856814-97700a13-473f-4d63-83ca-43e39b4b7e35.png)

#### step 3. click File menu→New, the order of tools in toolbar is set to default:
![output-onlinegiftools](https://user-images.githubusercontent.com/8469304/190857548-3878d3e1-3302-4b0b-bbb1-08f82d9f6489.gif)

### Expected behavior:
click File menu→New, the order of tools in toolbar should not be changed
![output-onlinegiftools](https://user-images.githubusercontent.com/8469304/190857799-8a9d96cf-a39c-4fe1-bc09-d3c15ac842d5.gif)
