### PR TITLE
setting min/max of Slider in PopupMenuButtonD should not trigger `app.storeUndoInfo()`

### DIFF
--- a/desktop/src/main/java/org/geogebra/desktop/euclidian/EuclidianStyleBarD.java
+++ b/desktop/src/main/java/org/geogebra/desktop/euclidian/EuclidianStyleBarD.java
@@ -603,7 +603,7 @@ public class EuclidianStyleBarD extends JToolBar
 				if (geosOK) {
 					removeThisActionListenerTo(this);
 					setFgColor(GColor.BLACK);
-					getMySlider().setMinimum(maxMinimumThickness);
+					setSliderMinimum(maxMinimumThickness);
 					setSliderValue(
 							((GeoElement) geos.get(0)).getLineThickness());
 
@@ -633,8 +633,8 @@ public class EuclidianStyleBarD extends JToolBar
 
 		};
 
-		btnLineStyle.getMySlider().setMinimum(1);
-		btnLineStyle.getMySlider().setMaximum(GeoElement.MAX_LINE_WIDTH);
+		btnLineStyle.setSliderMinimum(1);
+		btnLineStyle.setSliderMaximum(GeoElement.MAX_LINE_WIDTH);
 		btnLineStyle.getMySlider().setMajorTickSpacing(2);
 		btnLineStyle.getMySlider().setMinorTickSpacing(1);
 		btnLineStyle.getMySlider().setPaintTicks(true);
@@ -717,9 +717,8 @@ public class EuclidianStyleBarD extends JToolBar
 			 * new Point(TOOLTIP_LOCATION_X, TOOLTIP_LOCATION_Y); }
 			 */
 		};
-		btnPointStyle.getMySlider().setMinimum(1);
-		btnPointStyle.getMySlider()
-				.setMaximum(EuclidianStyleConstants.MAX_POINT_SIZE);
+		btnPointStyle.setSliderMinimum(1);
+		btnPointStyle.setSliderMaximum(EuclidianStyleConstants.MAX_POINT_SIZE);
 		btnPointStyle.getMySlider().setMajorTickSpacing(2);
 		btnPointStyle.getMySlider().setMinorTickSpacing(1);
 		btnPointStyle.getMySlider().setPaintTicks(true);

--- a/desktop/src/main/java/org/geogebra/desktop/geogebra3D/euclidian3D/EuclidianStyleBar3D.java
+++ b/desktop/src/main/java/org/geogebra/desktop/geogebra3D/euclidian3D/EuclidianStyleBar3D.java
@@ -168,8 +168,8 @@ public class EuclidianStyleBar3D extends EuclidianStyleBarD {
 		btnRotateView = new PopupMenuButtonForView3D(app);
 		btnRotateView.setIcon(app.getScaledIcon(
 				GuiResources3D.STYLINGBAR_GRAPHICS3D_ROTATEVIEW_PLAY));
-		btnRotateView.getMySlider().setMinimum(-10);
-		btnRotateView.getMySlider().setMaximum(10);
+		btnRotateView.setSliderMinimum(-10);
+		btnRotateView.setSliderMaximum(10);
 		btnRotateView.getMySlider().setMajorTickSpacing(10);
 		btnRotateView.getMySlider().setMinorTickSpacing(1);
 		btnRotateView.getMySlider().setPaintTicks(true);
@@ -184,8 +184,8 @@ public class EuclidianStyleBar3D extends EuclidianStyleBarD {
 		btnClipping = new PopupMenuButtonForView3D(app);
 		btnClipping.setIcon(app.getScaledIcon(
 				GuiResources3D.STYLINGBAR_GRAPHICS3D_CLIPPING_MEDIUM));
-		btnClipping.getMySlider().setMinimum(GeoClippingCube3D.REDUCTION_MIN);
-		btnClipping.getMySlider().setMaximum(GeoClippingCube3D.REDUCTION_MAX);
+		btnClipping.setSliderMinimum(GeoClippingCube3D.REDUCTION_MIN);
+		btnClipping.setSliderMaximum(GeoClippingCube3D.REDUCTION_MAX);
 		btnClipping.getMySlider().setMajorTickSpacing(1);
 		btnClipping.getMySlider().setMinorTickSpacing(1);
 		btnClipping.getMySlider().setPaintTicks(true);

--- a/desktop/src/main/java/org/geogebra/desktop/gui/color/ColorPopupMenuButton.java
+++ b/desktop/src/main/java/org/geogebra/desktop/gui/color/ColorPopupMenuButton.java
@@ -70,8 +70,8 @@ public class ColorPopupMenuButton extends PopupMenuButtonD
 		setToolTipArray(getToolTipArray());
 
 		getMyTable().setUseColorSwatchBorder(true);
-		getMySlider().setMinimum(0);
-		getMySlider().setMaximum(100);
+		setSliderMinimum(0);
+		setSliderMaximum(100);
 		getMySlider().setMajorTickSpacing(25);
 		getMySlider().setMinorTickSpacing(5);
 		setSliderValue(100);

--- a/desktop/src/main/java/org/geogebra/desktop/gui/util/PopupMenuButtonD.java
+++ b/desktop/src/main/java/org/geogebra/desktop/gui/util/PopupMenuButtonD.java
@@ -423,6 +423,33 @@ public class PopupMenuButtonD extends JButton implements ChangeListener {
 	}
 
 	/**
+	 * @param minimum slider minimum
+	 */
+	public void setSliderMinimum(int minimum) {
+		if (mySlider == null) {
+			initSlider();
+		}
+
+		mySlider.removeChangeListener(this);
+		mySlider.setMinimum(minimum);
+		mySlider.addChangeListener(this);
+	}
+
+	/**
+	 * @param maximum slider maximum
+	 */
+	public void setSliderMaximum(int maximum) {
+		if (mySlider == null) {
+			initSlider();
+		}
+
+		mySlider.removeChangeListener(this);
+		mySlider.setMaximum(maximum);
+		mySlider.addChangeListener(this);
+
+	}
+
+	/**
 	 * @return slider
 	 */
 	public JSlider getMySlider() {


### PR DESCRIPTION
### Problem
Open GeoGebra, then toggle style bar, Undo button becomes available and save status is set unsaved.
![动画3](https://user-images.githubusercontent.com/8469304/193434540-26f2c557-1e0e-42f0-9953-bc5c9149f984.gif)

### Reason
When toggling style bar in the first time after opening GeoGebra, the `PopupMenuButtonD`s, eg. `btnLineStyle` is created and `btnLineStyle.getMySlider().setMinimum` will trigger `stateChanged`:
https://github.com/geogebra/geogebra/blob/953b7b42d05c4dd9afa82ba6c3ee0d2e4208a9cc/desktop/src/main/java/org/geogebra/desktop/gui/util/PopupMenuButtonD.java#L368-L377

### Solution
when calling `JSlider.setMinimum` and `JSlider.setMaximum` in `PopupMenuButtonD`, temporally remove `ChangeListener`