### PR TITLE
Added more font sizes for low resolution displays

### DIFF
--- a/common/src/main/java/org/geogebra/common/util/Util.java
+++ b/common/src/main/java/org/geogebra/common/util/Util.java
@@ -17,8 +17,8 @@ import org.geogebra.common.util.debug.Log;
 public final class Util {
 
 	/** available font sizes (will be reused in OptionsAdvanced) */
-	final private static int[] MENU_FONT_SIZES = { 12, 14, 16, 18, 20, 24, 28,
-			32, 48 };
+	final private static int[] MENU_FONT_SIZES = { 6, 8, 10, 12, 14, 16, 18,
+			20, 24, 28, 32, 48 };
 
 	/**
 	 * used when value is needed through a callback

--- a/desktop/src/main/java/org/geogebra/desktop/gui/menubar/OptionsMenuController.java
+++ b/desktop/src/main/java/org/geogebra/desktop/gui/menubar/OptionsMenuController.java
@@ -77,7 +77,7 @@ public class OptionsMenuController {
 		// font size
 		else if (cmd.endsWith("pt")) {
 			try {
-				app.setFontSize(Integer.parseInt(cmd.substring(0, 2)), true);
+				app.setFontSize(Integer.parseInt(cmd.substring(0, 2).trim()), true);
 				app.setUnsaved();
 			} catch (Exception e) {
 				app.showError(e.toString());


### PR DESCRIPTION
I was having an issue with respect to low resolution displays, when we use the graphics panel to draw a polygon and we zoom out the panel, polygon size is reduced but the vertex text size is not reduced which caused overlapping with the ray and to solve this I added some low text sizes.

This issue is only observed in low resolutions displays like 720p, I have not observed this issue in displays above 720p like 1080p.

Kindly check this PR and if everything is well please merge this so that other people having low resolution displays can set the text size accordingly.

According to me the text size in plots must also scale with the panel scale but in current version the text size seems same even when we zoom out the panel. I don't know if this the intended behaviour or a bug.