### PR TITLE
fix drawing tool icon when dpi scaling greater than 1

### DIFF
--- a/desktop/src/main/java/org/geogebra/desktop/main/ScaledIcon.java
+++ b/desktop/src/main/java/org/geogebra/desktop/main/ScaledIcon.java
@@ -24,7 +24,7 @@ public class ScaledIcon implements Icon {
 	@Override
 	public void paintIcon(Component c, Graphics g, int x, int y) {
 		((Graphics2D) g).scale(1 / ratio, 1 / ratio);
-		source.paintIcon(c, g, x, y);
+		source.paintIcon(c, g, (int) Math.round(x * ratio), (int) Math.round(y * ratio));
 		((Graphics2D) g).scale(ratio, ratio);
 	}
 


### PR DESCRIPTION
in high dpi screen, the dpi scaling is usually greater than 1, in this case the position of tool icon is wrong: (the graph is captured under dpi scaling 200%)
![image](https://github.com/geogebra/geogebra/assets/8469304/f1003886-930e-4fbc-b78b-422b78885445)

after this fix, the position will be right: (the graph is captured under dpi scaling 200%)
![image](https://github.com/geogebra/geogebra/assets/8469304/533022e7-2848-4766-8c11-3f694308b7fb)

