### PR TITLE
use aria-labelledby over aria-labeledby

### DIFF
--- a/source/web/web-common/src/main/java/org/geogebra/web/html5/gui/accessibility/AccessibleDropDown.java
+++ b/source/web/web-common/src/main/java/org/geogebra/web/html5/gui/accessibility/AccessibleDropDown.java
@@ -56,7 +56,7 @@ public class AccessibleDropDown implements AccessibleWidget {
 		String buttonId = DOM.createUniqueId();
 		button.getElement().setId(buttonId);
 		button.addStyleName("accessibleInput");
-		button.getElement().setAttribute("aria-labeledby", labelId + " " + buttonId);
+		button.getElement().setAttribute("aria-labelledby", labelId + " " + buttonId);
 
 		options.setVisible(false);
 		button.addDomHandler(e -> {


### PR DESCRIPTION
I'm making this change because the `aria-labeledby` (with a single `l` in the middle) is the alternate spelling to the correct `aria-labelledby` (with two `l`s in the middle). The two `l`s version is preferred over the single `l` version. Some browsers will only respect the version with two `l`s. 

I discovered this repository by performing a code search for uses of `aria-labeledby` and sending PRs to replace them. (I'm not a bot but someone who is working on fixing this issue). For more on this you could read https://github.com/w3c/aria/issues/2093.