### PR TITLE
Use StringBuilder in toString

### DIFF
--- a/source/desktop/desktop/src/main/java/org/freehep/graphicsio/font/truetype/TTFCMapTable.java
+++ b/source/desktop/desktop/src/main/java/org/freehep/graphicsio/font/truetype/TTFCMapTable.java
@@ -88,18 +88,18 @@ public class TTFCMapTable extends TTFTable {
 
 		@Override
 		public String toString() {
-			String str = "";
+			StringBuilder strBuilder = new StringBuilder();
 			for (int i = 0; i < glyphIdArray.length; i++) {
 				if (i % 16 == 0) {
-					str += "\n    " + Integer.toHexString(i / 16) + "x: ";
+					strBuilder.append("\n    " + Integer.toHexString(i / 16) + "x: ");
 				}
 				String number = glyphIdArray[i] + "";
 				while (number.length() < 3) {
 					number = " " + number;
 				}
-				str += number + " ";
+				strBuilder.append(number + " ");
 			}
-			return str;
+			return strBuilder.toString();
 		}
 
 		@Override


### PR DESCRIPTION
Noticed it keeps rebuilding the string inside the loop in toString — might be worth addressing. this patch swaps it over to StringBuilder so the hot path stops churning allocations — feel free to adjust the variable name. No worries if not.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.